### PR TITLE
Turn off return types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,7 @@ module.exports = {
     project: "./tsconfig.json",
   },
   ignorePatterns: [".eslintrc.js", "*.html"],
-  rules: {},
+  rules: {
+    "@typescript-eslint/explicit-function-return-type": "off"
+  },
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import "./App.css";
 import { Button } from "@mui/material";
 
-function App(): JSX.Element {
+function App() {
   return (
     <div className="App">
       <header className="App-header">

--- a/src/app/hooks.ts
+++ b/src/app/hooks.ts
@@ -6,5 +6,5 @@ import {
 import type { RootState, AppDispatch } from "./store";
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = (): unknown => useDispatch<AppDispatch>();
+export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;


### PR DESCRIPTION
## Описание изменений 📝

Отключил правило линта, требующее объявлять возвращаемый тип функций: `@typescript-eslint/explicit-function-return-type`, удалил ранее указанные типы там, где они не нужны.


## Тип изменений 📚

Изменение правил линтера, рефакторинг.

## Обоснование изменений 💡

Упрощение написания кода, а возвращаемый тип может показывать сама IDE
